### PR TITLE
Issue-40: replaced predict with predict.movementmoded in docs

### DIFF
--- a/R/movement.R
+++ b/R/movement.R
@@ -19,9 +19,9 @@
 #' @param \dots Extra parameters to be passed to the prediction code.
 #' @return An \code{optimisedmodel} object containing the training results,
 #' and the optimisation results. This can then be used by 
-#' \code{\link{predict}} to generate predictions on new data.
+#' \code{\link{predict.movementmodel}} to generate predictions on new data.
 #'
-#' @seealso \code{\link{predict}}, \code{\link{as.locationdataframe}},
+#' @seealso \code{\link{predict.movementmodel}}, \code{\link{as.locationdataframe}},
 #' \code{\link{as.movementmatrix}}
 #' @note The most likely format of the location data will be as a single
 #' \code{data.frame} of this form:
@@ -777,7 +777,7 @@ movement.predict <- function(distance, population,
 #' between locations.
 #' @param \dots Extra parameters to pass to plot
 #'
-#' @seealso \code{\link{movementmodel}}, \code{\link{predict}}
+#' @seealso \code{\link{movementmodel}}, \code{\link{predict.movementmodel}}
 #' @export
 show.prediction <- function(network, raster_layer, predictedMovements, ...) {
   # visualise the distance matrix
@@ -834,7 +834,7 @@ show.prediction <- function(network, raster_layer, predictedMovements, ...) {
 #' # visualise the predicted movements overlaid onto the original raster
 #' showprediction(predictedMovements)
 #'
-#' @seealso \code{\link{movementmodel}}, \code{\link{predict}}
+#' @seealso \code{\link{movementmodel}}, \code{\link{predict.movementmodel}}
 #' @export
 showprediction <- function(object, ...) {
   UseMethod("showprediction", object)
@@ -1037,7 +1037,7 @@ get.network.fromdataframe <- function(dataframe, min = 1, matrix = TRUE) {
 #' # visualise the predicted movements overlaid onto the original raster
 #' showprediction(predictedMovements)
 #'
-#' @seealso \code{\link{predict}}, \code{\link{showprediction}}
+#' @seealso \code{\link{predict.movementmodel}}, \code{\link{showprediction}}
 #' @export
 movementmodel <- function(dataset, min_network_pop = 50000, predictionmodel = 'original radiation', symmetric = TRUE, modelparams = 0.1) {
   me <- list(

--- a/man/movement.Rd
+++ b/man/movement.Rd
@@ -29,7 +29,7 @@ models are \code{original radiation}, \code{radiation with selection},
 \value{
 An \code{optimisedmodel} object containing the training results,
 and the optimisation results. This can then be used by
-\code{\link{predict}} to generate predictions on new data.
+\code{\link{predict.movementmodel}} to generate predictions on new data.
 }
 \description{
 Uses the \code{\link{optim}} method to create an optimised model of
@@ -68,7 +68,7 @@ sp::plot(raster::raster(predictedMovements$net$distance_matrix))
 showprediction(predictedMovements)
 }
 \seealso{
-\code{\link{predict}}, \code{\link{as.locationdataframe}},
+\code{\link{predict.movementmodel}}, \code{\link{as.locationdataframe}},
 \code{\link{as.movementmatrix}}
 }
 

--- a/man/show.prediction.Rd
+++ b/man/show.prediction.Rd
@@ -21,6 +21,6 @@ between locations.}
 Display the movement predictions on a plot
 }
 \seealso{
-\code{\link{movementmodel}}, \code{\link{predict}}
+\code{\link{movementmodel}}, \code{\link{predict.movementmodel}}
 }
 

--- a/man/showprediction.Rd
+++ b/man/showprediction.Rd
@@ -33,6 +33,6 @@ sp::plot(raster::raster(predictedMovements$net$distance_matrix))
 showprediction(predictedMovements)
 }
 \seealso{
-\code{\link{movementmodel}}, \code{\link{predict}}
+\code{\link{movementmodel}}, \code{\link{predict.movementmodel}}
 }
 


### PR DESCRIPTION
As suggested link explicit the predict.movementmodel in the documentation instead of the generic predict() method which will not correctly display the predict model used in this package