### PR TITLE
Issue 98: add the tests for parallel computation back in; but

### DIFF
--- a/tests/testthat/test_model_prediction.R
+++ b/tests/testthat/test_model_prediction.R
@@ -131,23 +131,27 @@ test_that("movement.predict produces correct result for simple case 2 with non-s
   expect_equal(actual, expected_matrix)
 })
 
-# test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 1 cores", {
-#   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
-#   population <- c(500, 1000,2000, 5000)
-#   mock_flux <- function(i, j, distance, population, symmetric) return (5)
-#   actual <- movement.predict(distance, population, flux=mock_flux, progress = FALSE, go_parallel = TRUE, number_of_cores = 1)
-#   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
-#   expect_equal(actual, expected_matrix)
-# })
+test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 1 cores", {
+  testthat::skip_on_cran()
+  testthat::skip_on_travis()
+  distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
+  population <- c(500, 1000,2000, 5000)
+  mock_flux <- function(i, j, distance, population, symmetric) return (5)
+  actual <- movement.predict(distance, population, flux=mock_flux, progress = FALSE, go_parallel = TRUE, number_of_cores = 1)
+  expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
+  expect_equal(actual, expected_matrix)
+})
 
-# test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 2 cores", {
-#   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
-#   population <- c(500, 1000,2000, 5000)
-#   mock_flux <- function(i, j, distance, population, symmetric) return (5)
-#   actual <- movement.predict(distance, population, flux=mock_flux, progress = FALSE, go_parallel = TRUE, number_of_cores = 2)
-#   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
-#   expect_equal(actual, expected_matrix)
-# })
+test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 2 cores", {
+  testthat::skip_on_cran()
+  testthat::skip_on_travis()
+  distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
+  population <- c(500, 1000,2000, 5000)
+  mock_flux <- function(i, j, distance, population, symmetric) return (5)
+  actual <- movement.predict(distance, population, flux=mock_flux, progress = FALSE, go_parallel = TRUE, number_of_cores = 2)
+  expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
+  expect_equal(actual, expected_matrix)
+})
 
 test_that("movement.predict produces correct result for simple case with symmetric distances", {
 	distance <- matrix(c(0,1,1,0),nrow=2)
@@ -166,21 +170,25 @@ test_that("movement.predict produces correct result for simple case 2 with symme
   expect_equal(actual, expected_matrix)
 })
 
-# test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 1 cores", {
-#   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
-#   population <- c(500, 1000,2000, 5000)
-#   mock_flux <- function(i, j, distance, population, symmetric) return (5)
-#   actual <- movement.predict(distance, population, flux=mock_flux, symmetric=TRUE, progress = FALSE, go_parallel = TRUE, number_of_cores = 1)
-#   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
-#   expect_equal(actual, expected_matrix)
-# })
+test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 1 cores", {
+  testthat::skip_on_cran()
+  testthat::skip_on_travis()
+  distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
+  population <- c(500, 1000,2000, 5000)
+  mock_flux <- function(i, j, distance, population, symmetric) return (5)
+  actual <- movement.predict(distance, population, flux=mock_flux, symmetric=TRUE, progress = FALSE, go_parallel = TRUE, number_of_cores = 1)
+  expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
+  expect_equal(actual, expected_matrix)
+})
 
-# test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 2 cores", {
-#   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
-#   population <- c(500, 1000,2000, 5000)
-#   mock_flux <- function(i, j, distance, population, symmetric) return (5)
-#   actual <- movement.predict(distance, population, flux=mock_flux, symmetric=TRUE, progress = FALSE, go_parallel = TRUE, number_of_cores = 2)
-#   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
-#   expect_equal(actual, expected_matrix)
-# })
+test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 2 cores", {
+  testthat::skip_on_cran()
+  testthat::skip_on_travis()
+  distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
+  population <- c(500, 1000,2000, 5000)
+  mock_flux <- function(i, j, distance, population, symmetric) return (5)
+  actual <- movement.predict(distance, population, flux=mock_flux, symmetric=TRUE, progress = FALSE, go_parallel = TRUE, number_of_cores = 2)
+  expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
+  expect_equal(actual, expected_matrix)
+})
 

--- a/tests/testthat/test_model_prediction.R
+++ b/tests/testthat/test_model_prediction.R
@@ -131,10 +131,9 @@ test_that("movement.predict produces correct result for simple case 2 with non-s
   expect_equal(actual, expected_matrix)
 })
 
-if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 1 cores", {
+  testthat::skip_on_travis()
   testthat::skip_on_cran()
-  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -142,12 +141,10 @@ test_that("movement.predict produces correct result for simple case with non-sym
   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
-}
 
-if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 2 cores", {
+  testthat::skip_on_travis()
   testthat::skip_on_cran()
-  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -155,7 +152,6 @@ test_that("movement.predict produces correct result for simple case with non-sym
   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
-}
 
 test_that("movement.predict produces correct result for simple case with symmetric distances", {
 	distance <- matrix(c(0,1,1,0),nrow=2)
@@ -174,10 +170,9 @@ test_that("movement.predict produces correct result for simple case 2 with symme
   expect_equal(actual, expected_matrix)
 })
 
-if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 1 cores", {
+  testthat::skip_on_travis()
   testthat::skip_on_cran()
-  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -185,12 +180,11 @@ test_that("movement.predict produces correct result for simple case with symmetr
   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
-}
 
-if (!isTRUE(Sys.getenv('TRAVIS'))) {
+
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 2 cores", {
+  testthat::skip_on_travis()
   testthat::skip_on_cran()
-  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -198,4 +192,3 @@ test_that("movement.predict produces correct result for simple case with symmetr
   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
-}

--- a/tests/testthat/test_model_prediction.R
+++ b/tests/testthat/test_model_prediction.R
@@ -131,9 +131,10 @@ test_that("movement.predict produces correct result for simple case 2 with non-s
   expect_equal(actual, expected_matrix)
 })
 
+if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 1 cores", {
-  #testthat::skip_on_cran()
-  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -141,10 +142,12 @@ test_that("movement.predict produces correct result for simple case with non-sym
   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
+}
 
+if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 2 cores", {
-  #testthat::skip_on_cran()
-  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -152,6 +155,7 @@ test_that("movement.predict produces correct result for simple case with non-sym
   expected_matrix  <- matrix(c(0,NA,NA,NA,5,0,NA,NA,5,5,0,NA, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
+}
 
 test_that("movement.predict produces correct result for simple case with symmetric distances", {
 	distance <- matrix(c(0,1,1,0),nrow=2)
@@ -170,9 +174,10 @@ test_that("movement.predict produces correct result for simple case 2 with symme
   expect_equal(actual, expected_matrix)
 })
 
+if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 1 cores", {
-  #testthat::skip_on_cran()
-  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -180,10 +185,12 @@ test_that("movement.predict produces correct result for simple case with symmetr
   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
+}
 
+if (!isTRUE(Sys.getenv('TRAVIS'))) {
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 2 cores", {
-  #testthat::skip_on_cran()
-  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  #testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
   mock_flux <- function(i, j, distance, population, symmetric) return (5)
@@ -191,4 +198,4 @@ test_that("movement.predict produces correct result for simple case with symmetr
   expected_matrix  <- matrix(c(0,5,5,5,5,0,5,5,5,5,0, 5, 5,5,5,0), nrow = 4)
   expect_equal(actual, expected_matrix)
 })
-
+}

--- a/tests/testthat/test_model_prediction.R
+++ b/tests/testthat/test_model_prediction.R
@@ -132,7 +132,7 @@ test_that("movement.predict produces correct result for simple case 2 with non-s
 })
 
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 1 cores", {
-  testthat::skip_on_cran()
+  #testthat::skip_on_cran()
   testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
@@ -143,7 +143,7 @@ test_that("movement.predict produces correct result for simple case with non-sym
 })
 
 test_that("movement.predict produces correct result for simple case with non-symmetric distances running parallel on 2 cores", {
-  testthat::skip_on_cran()
+  #testthat::skip_on_cran()
   testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
@@ -171,7 +171,7 @@ test_that("movement.predict produces correct result for simple case 2 with symme
 })
 
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 1 cores", {
-  testthat::skip_on_cran()
+  #testthat::skip_on_cran()
   testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)
@@ -182,7 +182,7 @@ test_that("movement.predict produces correct result for simple case with symmetr
 })
 
 test_that("movement.predict produces correct result for simple case with symmetric distances running parallel on 2 cores", {
-  testthat::skip_on_cran()
+  #testthat::skip_on_cran()
   testthat::skip_on_travis()
   distance <- matrix(c(0,1,2,3, 1,2,3, 0,2,3, 0,1, 3, 0, 1, 2),nrow=4)
   population <- c(500, 1000,2000, 5000)


### PR DESCRIPTION
call the 'skip_on_travis' and 'skip_on_cran' as these tests won't run there
-> run the travis test to check that the fix is working correctly. 

(relate to issue https://github.com/SEEG-Oxford/movement/issues/98)